### PR TITLE
Update docker compose command

### DIFF
--- a/run
+++ b/run
@@ -2,7 +2,7 @@
 
 function cleanup() {
   pushd compose
-  docker-compose -p boundary rm -fs 
+  docker compose -p boundary rm -fs 
   popd
   pushd terraform/
   rm terraform.tfstate*
@@ -15,7 +15,7 @@ trap cleanup SIGKILL SIGINT
 
 function init_compose() {
   pushd compose/
-  docker-compose --project-name boundary up -d
+  docker compose --project-name boundary up -d
   popd
 }
 


### PR DESCRIPTION
Updates the old command `docker-compose` to the new version `docker compose`.

This PR should be merged in conjunction with [docs: Fix broken commands in upgrade tutorial #2274](https://github.com/hashicorp/tutorials/pull/2274).